### PR TITLE
Function chNodeGetMemoryStats has missing return type

### DIFF
--- a/src/ch/ch_driver.c
+++ b/src/ch/ch_driver.c
@@ -2282,6 +2282,7 @@ chConnectDomainEventDeregisterAny(virConnectPtr conn,
 }
 
 
+static int
 chNodeGetMemoryStats(virConnectPtr conn,
                        int cellNum,
                        virNodeMemoryStatsPtr params,


### PR DESCRIPTION
92.08 FAILED: src/ch/libvirt_driver_ch_impl.a.p/ch_driver.c.o 
92.08 ../src/ch/ch_driver.c:2285:1: error: return type defaults to 'int' [-Werror=implicit-int]
92.08  2285 | chNodeGetMemoryStats(virConnectPtr conn,
92.08       | ^~~~~~~~~~~~~~~~~~~~
92.08 ../src/ch/ch_driver.c:2285:1: error: no previous prototype for 'chNodeGetMemoryStats' [-Werror=missing-prototypes]
92.08 cc1: all warnings being treated as errors
